### PR TITLE
Use force=True in get_json to prevent 500 error on !json requests

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -119,7 +119,7 @@ def verify_jwt(realm=None):
 class JWTAuthView(MethodView):
 
     def post(self):
-        data = request.get_json()
+        data = request.get_json(force=True)
         username = data.get('username', None)
         password = data.get('password', None)
         criterion = [username, password, len(data) == 2]


### PR DESCRIPTION
```
username = data.get('username', None)
AttributeError: 'NoneType' object has no attribute 'get'
```
