### PR TITLE
Add response_handler hook/decorator

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -47,6 +47,11 @@ def _default_decode_handler(token):
         current_app.config['JWT_LEEWAY']
     )
 
+
+def _default_response_handler(payload):
+    """Return a Flask response, given an encoded payload."""
+    return jsonify({'token': payload})
+
 CONFIG_DEFAULTS = {
     'JWT_DEFAULT_REALM': 'Login Required',
     'JWT_AUTH_URL_RULE': '/auth',
@@ -133,7 +138,9 @@ class JWTAuthView(MethodView):
             payload_handler = current_app.config['JWT_PAYLOAD_HANDLER']
             payload = payload_handler(user)
             encode_handler = current_app.config['JWT_ENCODE_HANDLER']
-            return jsonify({'token': encode_handler(payload)})
+
+            token = encode_handler(payload)
+            return _jwt.response_callback(token)
         else:
             raise JWTError('Bad Request', 'Invalid credentials')
 
@@ -146,6 +153,8 @@ class JWT(object):
             self.init_app(app)
         else:
             self.app = None
+
+        self.response_callback = _default_response_handler
 
     def init_app(self, app):
         for k, v in CONFIG_DEFAULTS.items():
@@ -216,4 +225,13 @@ class JWT(object):
         :param callback: the error handler function
         """
         self.error_callback = callback
+        return callback
+
+    def response_handler(self, callback):
+        """Specifies the response handler function. this function receives a
+        JWT-encoded payload and returns a Flask response.
+
+        :param callable callback: the response handler function
+        """
+        self.response_callback = callback
         return callback

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -5,10 +5,9 @@
 
     Flask-JWT tests
 """
-import os
 import time
 
-from flask import Flask, json
+from flask import Flask, json, jsonify
 
 import flask_jwt
 
@@ -174,3 +173,20 @@ def test_custom_error_handler(client, jwt):
 
     r = client.get('/protected')
     assert r.data == b'custom'
+
+
+def test_custom_response_handler(client, jwt):
+
+    @jwt.response_handler
+    def resp_handler(payload):
+        return jsonify({'mytoken': payload})
+
+    r = client.post(
+        '/auth',
+        headers={'content-type': 'application/json'},
+        data=json.dumps({
+            'username': 'joe',
+            'password': 'pass'
+        }))
+    jdata = json.loads(r.data)
+    assert 'mytoken' in jdata


### PR DESCRIPTION
Adds a `response_handler` hook that allows for custom formatting of the output response for the auth endpoint.

Example

``` python
@jwt.response_handler
def handle_response(token):
    return jsonify({'mytoken': token})

# POST /auth  => {"mytoken": 'abc123...'}
```

This control over the response is absolutely necessary when using libraries that automatically JSONify the return value of your views. For example, [Flask-API](https://github.com/tomchristie/flask-api) and [Flask-RESTful](https://github.com/twilio/flask-restful) extensions expect views to return dictionaries. The extensions handle the "jsonification".

Without a means for overriding flask-jwt's response behavior, your token payload gets jsonified twice!
