### PR TITLE
Another attempt to fix coveralls

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,8 @@ class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
         self.test_args = [
-            '--cov', 'flask_jwt',
-            '--cov-report', 'term-missing',
-            '--pep8'
+            '--verbose',
+            '--pep8',
         ]
         self.test_suite = True
 


### PR DESCRIPTION
My thought is that pytest-cov may be conflicting with the `coverage run` command in .travis.yml.
