### PR TITLE
Expired tokens should return 401

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -126,7 +126,9 @@ def verify_jwt(realm=None):
         handler = _jwt.decode_callback
         payload = handler(parts[1])
     except SignatureExpired:
-        raise JWTError('Invalid JWT', 'Token is expired')
+        raise JWTError('Expired JWT', 'Token is expired', 401, {
+            "WWW-Authenticate": 'JWT realm="{0}"'.format(realm)
+        })
     except BadSignature:
         raise JWTError('Invalid JWT', 'Token is undecipherable')
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -157,7 +157,7 @@ def test_jwt_required_decorator_with_invalid_jwt_tokens(client, user):
     # Expired
     time.sleep(1.5)
     r = client.get('/protected', headers={'authorization': 'Bearer ' + token})
-    assert_error_response(r, 400, 'Invalid JWT', 'Token is expired')
+    assert_error_response(r, 401, 'Expired JWT', 'Token is expired')
 
 
 def test_jwt_required_decorator_with_missing_user(client, jwt, user):


### PR DESCRIPTION
An expired JWT should return a 401 so the end user/client knows that they should re-authenticate and try again.
