### PR TITLE
Custom username and password key for auth payload

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -109,6 +109,10 @@ Configuration Options
                            ``/auth``.
 ``JWT_AUTH_ENDPOINT``      The authentication endpoint name. Defaults to
                            ``jwt``.
+``JWT_AUTH_USERNAME_KEY``  The username key in the authentication request payload.
+                           Defaults to ``username``.
+``JWT_AUTH_PASSWORD_KEY``  The password key in the authentication request payload.
+                           Defaults to ``password``.
 ``JWT_ALGORITHM``          The token algorithm. Defaults to ``HS256``
 ``JWT_VERIFY``             Flag indicating if all tokens should be verified.
                            Defaults to ``True``. It is not recommended to change

--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -68,6 +68,8 @@ CONFIG_DEFAULTS = {
     'JWT_DEFAULT_REALM': 'Login Required',
     'JWT_AUTH_URL_RULE': '/auth',
     'JWT_AUTH_ENDPOINT': 'jwt',
+    'JWT_AUTH_USERNAME_KEY': 'username',
+    'JWT_AUTH_PASSWORD_KEY': 'password',
     'JWT_ALGORITHM': 'HS256',
     'JWT_VERIFY': True,
     'JWT_VERIFY_EXPIRATION': True,
@@ -152,14 +154,14 @@ class JWTAuthView(MethodView):
 
     def post(self):
         data = request.get_json(force=True)
-        username = data.get('username', None)
-        password = data.get('password', None)
+        username = data.get(current_app.config.get('JWT_AUTH_USERNAME_KEY'), None)
+        password = data.get(current_app.config.get('JWT_AUTH_PASSWORD_KEY'), None)
         criterion = [username, password, len(data) == 2]
 
         if not all(criterion):
             raise JWTError('Bad Request', 'Missing required credentials', status_code=400)
 
-        user = _jwt.authentication_callback(username=username, password=password)
+        user = _jwt.authentication_callback(username, password)
 
         if user:
             token = generate_token(user)

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -60,6 +60,18 @@ def test_auth_endpoint_with_valid_request(client, user):
     assert 'token' in jdata
 
 
+def test_custom_auth_endpoint_with_valid_request(app, client, user):
+    app.config['JWT_AUTH_USERNAME_KEY'] = 'email'
+    app.config['JWT_AUTH_PASSWORD_KEY'] = 'pass'
+    resp, jdata = post_json(
+        client,
+        '/auth',
+        {'email': user.username, 'pass': user.password}
+    )
+    assert resp.status_code == 200
+    assert 'token' in jdata
+
+
 def test_auth_endpoint_with_invalid_request(client, user):
     # Invalid request (no password)
     resp, jdata = post_json(client, '/auth', {'username': user.username})


### PR DESCRIPTION
Hello, I added config options to parameterize the payload of `JWTAuthView`. Currently, it expects a payload of:
```json
{
  "username": "johnsmith",
  "password": "hunter2"
}
```
With this change, one could customize those keys to accept the following payload:
```python
app.config['JWT_AUTH_USERNAME_KEY'] = 'email'
app.config['JWT_AUTH_PASSWORD_KEY'] = 'pass'
```
```json
{
  "email": "johnsmith@foo.com",
  "pass": "hunter2"
}
```