### PR TITLE
Added custom handler for authenticating via payload

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -65,10 +65,11 @@ def _default_response_handler(payload):
     return jsonify({'token': payload})
 
 
-def _default_payload_auth_handler(payload):
-    username = payload.get('username', None)
-    password = payload.get('password', None)
-    criterion = [username, password, len(payload) == 2]
+def _default_payload_auth_handler(request):
+    data = request.get_json(force=True)
+    username = data.get('username', None)
+    password = data.get('password', None)
+    criterion = [username, password, len(data) == 2]
 
     if not all(criterion):
         raise JWTError('Bad Request', 'Missing required credentials', status_code=400)
@@ -164,10 +165,8 @@ def generate_token(user):
 class JWTAuthView(MethodView):
 
     def post(self):
-        data = request.get_json(force=True)
 
-        user = _jwt.payload_authentication_callback(data)
-
+        user = _jwt.payload_authentication_callback(request)
         if user:
             token = generate_token(user)
             return _jwt.response_callback(token)

--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -249,7 +249,6 @@ class JWT(object):
         self.payload_authentication_callback = callback
         return callback
 
-
     def user_handler(self, callback):
         """Specifies the user handler function. This function receives the token payload as
         its only positional argument. It should return an object representing the current


### PR DESCRIPTION
Providing a way to overwrite the default payload handler for the http post requests - this way someone could implement an easy solution for refresh the token. This also allows for more complex auth requests (i.e. including permission levels etc.) 
