### PR TITLE
Added try/except to flash-jwt/__init__.py to intercept call to non-ex…

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -30,7 +30,13 @@ _jwt = LocalProxy(lambda: current_app.extensions['jwt'])
 def _get_serializer():
     expires_in = current_app.config['JWT_EXPIRATION_DELTA']
     if isinstance(expires_in, timedelta):
-        expires_in = int(expires_in.total_seconds())
+        try:
+                expires_in = int(expires_in.total_seconds())
+        except AttributeError:
+                expires_in = int((expires_in.microseconds + 0.0 
+                                 + (expires_in.seconds + expires_in.days * 24 * 3600) * 10 ** 6) 
+                                 / 10 ** 6)
+
     expires_in_total = expires_in + current_app.config['JWT_LEEWAY']
     return TimedJSONWebSignatureSerializer(
         secret_key=current_app.config['JWT_SECRET_KEY'],

--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -34,7 +34,7 @@ def _get_serializer():
                 expires_in = int(expires_in.total_seconds())
         except AttributeError:
                 expires_in = int((expires_in.microseconds + 0.0 +
-                                 (expires_in.seconds + expires_in.days * 24 * 3600) * 10 ** 6) / 
+                                 (expires_in.seconds + expires_in.days * 24 * 3600) * 10 ** 6) /
                                  10 ** 6)
 
     expires_in_total = expires_in + current_app.config['JWT_LEEWAY']

--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -33,9 +33,9 @@ def _get_serializer():
         try:
                 expires_in = int(expires_in.total_seconds())
         except AttributeError:
-                expires_in = int((expires_in.microseconds + 0.0 
-                                 + (expires_in.seconds + expires_in.days * 24 * 3600) * 10 ** 6) 
-                                 / 10 ** 6)
+                expires_in = int((expires_in.microseconds + 0.0 +
+                                 (expires_in.seconds + expires_in.days * 24 * 3600) * 10 ** 6) / 
+                                 10 ** 6)
 
     expires_in_total = expires_in + current_app.config['JWT_LEEWAY']
     return TimedJSONWebSignatureSerializer(


### PR DESCRIPTION
The current version does not work with Python 2.6.x due to a call to total_seconds() in flask-jwt/**init**.py. I added a try/catch to handle the call in 2.6 and replaced the calculation with an inline formula.
