### PR TITLE
Fix incorrect id resolution

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -50,7 +50,11 @@ def _default_jwt_payload_handler(identity):
     iat = datetime.utcnow()
     exp = iat + current_app.config.get('JWT_EXPIRATION_DELTA')
     nbf = iat + current_app.config.get('JWT_NOT_BEFORE_DELTA')
-    identity = getattr(identity, 'id', identity['id'])
+    try:
+        identity = getattr(identity, 'id')
+    except AttributeError:
+        identity = identity['id']
+    
     return {'exp': exp, 'iat': iat, 'nbf': nbf, 'identity': identity}
 
 

--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -50,7 +50,7 @@ def _default_jwt_payload_handler(identity):
     iat = datetime.utcnow()
     exp = iat + current_app.config.get('JWT_EXPIRATION_DELTA')
     nbf = iat + current_app.config.get('JWT_NOT_BEFORE_DELTA')
-    identity = getattr(identity, 'id') or identity['id']
+    identity = getattr(identity, 'id', identity['id'])
     return {'exp': exp, 'iat': iat, 'nbf': nbf, 'identity': identity}
 
 


### PR DESCRIPTION
The current code does not correctly resolve the id from the intended order: attribute -> key, but instead will raise an AttributeError if there is no such attribute. It will also not accept a falsy .id attribute, e.g. 0. This patch fixes the issue.
