### PR TITLE
do not server error on non-json auth attempt

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -112,6 +112,10 @@ def _default_request_handler():
 
 def _default_auth_request_handler():
     data = request.get_json()
+
+    if not data:
+        raise JWTError('Bad Request', 'Credentials must supplied in JSON')
+
     username = data.get(current_app.config.get('JWT_AUTH_USERNAME_KEY'), None)
     password = data.get(current_app.config.get('JWT_AUTH_PASSWORD_KEY'), None)
     criterion = [username, password, len(data) == 2]


### PR DESCRIPTION
Fix for issue #58

request.get_json() returns None if request content type is not application/json, it is not handled more gracefully than a 500 Server Error.
