### PR TITLE
raise exception if invalid json in body

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -112,6 +112,9 @@ def _default_request_handler():
 
 def _default_auth_request_handler():
     data = request.get_json()
+    if data is None:
+        raise JWTError('Bad Request', 'Invalid JSON Body')
+
     username = data.get(current_app.config.get('JWT_AUTH_USERNAME_KEY'), None)
     password = data.get(current_app.config.get('JWT_AUTH_PASSWORD_KEY'), None)
     criterion = [username, password, len(data) == 2]

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -93,6 +93,19 @@ def test_auth_endpoint_with_invalid_credentials(client):
     assert jdata['status_code'] == 401
 
 
+def test_auth_endpoint_with_invalid_body_post(client):
+    resp = client.post('/auth', headers={})
+    jdata = json.loads(resp.data)
+
+    assert resp.status_code == 401
+    assert 'error' in jdata
+    assert jdata['error'] == 'Bad Request'
+    assert 'description' in jdata
+    assert jdata['description'] == 'Invalid JSON Body'
+    assert 'status_code' in jdata
+    assert jdata['status_code'] == 401
+
+
 def test_jwt_required_decorator_with_valid_token(app, client, user):
     resp, jdata = post_json(
         client, '/auth', {'username': user.username, 'password': user.password})


### PR DESCRIPTION
It was throwing this error : 

```
Traceback (most recent call last):
  File "/home/jobou/workspace/weenect-api/venv/lib/python3.4/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/jobou/workspace/weenect-api/venv/lib/python3.4/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/jobou/workspace/weenect-api/venv/lib/python3.4/site-packages/flask_jwt/__init__.py", line 115, in _default_auth_request_handler
    username = data.get(current_app.config.get('JWT_AUTH_USERNAME_KEY'), None)
AttributeError: 'NoneType' object has no attribute 'get'
```
