### PR TITLE
Cleaned up doc strings

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -274,7 +274,7 @@ class JWT(object):
     def jwt_error_handler(self, callback):
         """Specifies the error handler function. Example::
 
-            @jwt.error_handler
+            @jwt.jwt_error_handler
             def error_handler(e):
                 return "Something bad happened", 400
 
@@ -337,7 +337,7 @@ class JWT(object):
 
         Example::
 
-            @jwt.payload_handler
+            @jwt.jwt_payload_handler
             def make_payload(identity):
                 return {'user_id': identity.id}
 
@@ -352,11 +352,11 @@ class JWT(object):
 
         Example::
 
-            @jwt.payload_handler
-            def make_payload(identity):
+            @jwt.jwt_headers_handler
+            def make_header(identity):
                 return {'user_id': identity.id}
 
-        :param callable callback: the payload handler function
+        :param callable callback: the header handler function
         """
         self.jwt_headers_callback = callback
         return callback


### PR DESCRIPTION
Just updated the docstring examples to match the new function names. I wasn't sure what a good example for jwt_headers_handler would be, so I pretty much left it the same, feel free to add something better.
