### PR TITLE
Stop 500's on a non-JSON /auth request

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -111,12 +111,12 @@ def _default_request_handler():
 
 
 def _default_auth_request_handler():
-    data = request.get_json()
-    username = data.get(current_app.config.get('JWT_AUTH_USERNAME_KEY'), None)
-    password = data.get(current_app.config.get('JWT_AUTH_PASSWORD_KEY'), None)
-    criterion = [username, password, len(data) == 2]
+    data = request.get_json() or {}
+    username = data.get(current_app.config.get('JWT_AUTH_USERNAME_KEY'))
+    password = data.get(current_app.config.get('JWT_AUTH_PASSWORD_KEY'))
+    criteria = [username, password, len(data) == 2]
 
-    if not all(criterion):
+    if not all(criteria):
         raise JWTError('Bad Request', 'Invalid credentials')
 
     identity = _jwt.authentication_callback(username, password)

--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -111,7 +111,10 @@ def _default_request_handler():
 
 
 def _default_auth_request_handler():
-    data = request.get_json() or {}
+    data = request.get_json()
+    if not isinstance(data, dict):  # Strings/arrays, or non-JSON mimetype
+        raise JWTError('Bad Request', 'Credentials must be a JSON object')
+
     username = data.get(current_app.config.get('JWT_AUTH_USERNAME_KEY'))
     password = data.get(current_app.config.get('JWT_AUTH_PASSWORD_KEY'))
     criteria = [username, password, len(data) == 2]


### PR DESCRIPTION
When the request is not JSON (and the `force` flag is False), Flask's [`get_json()`](https://github.com/mitsuhiko/flask/blob/0.10.1/flask/wrappers.py#L127) will return `None`.

If somebody POSTs to `/auth` with a non-JSON mimetype, the server will 500 with `'NoneType' object has no attribute 'get'`.

This fixes this behavior in the default `auth_request_handler`.
