### PR TITLE
Allow fallback to 'id' key

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -50,7 +50,7 @@ def _default_jwt_payload_handler(identity):
     iat = datetime.utcnow()
     exp = iat + current_app.config.get('JWT_EXPIRATION_DELTA')
     nbf = iat + current_app.config.get('JWT_NOT_BEFORE_DELTA')
-    identity = getattr(identity, 'id') or identity['id']
+    identity = getattr(identity, 'id', None) or identity['id']
     return {'exp': exp, 'iat': iat, 'nbf': nbf, 'identity': identity}
 
 


### PR DESCRIPTION
If identity is a dictionary, `identity = getattr(identity, 'id') or identity['id']` fails with `AttributeError: 'dict' object has no attribute 'id'`

Setting the default allows the `id` key to be used.
