### PR TITLE
make the default jwt_payload_handler work even if the identity has no 'id' attribute

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -50,7 +50,7 @@ def _default_jwt_payload_handler(identity):
     iat = datetime.utcnow()
     exp = iat + current_app.config.get('JWT_EXPIRATION_DELTA')
     nbf = iat + current_app.config.get('JWT_NOT_BEFORE_DELTA')
-    identity = getattr(identity, 'id') or identity['id']
+    identity = getattr(identity, 'id', None) or identity['id']
     return {'exp': exp, 'iat': iat, 'nbf': nbf, 'identity': identity}
 
 


### PR DESCRIPTION
The default implementation of `jwt_payload_handler` fails if the `identity` object has no `id` attribute, even though it was clearly an intention to fall back to a dictionary lookup when such an attribute does not exist. The current implementation fails because `getattr` throws an `AttributeError` for missing attributes if no default value is provided. The patch fixes this by providing a default value of `None` for the attribute lookup, preventing the exception.
