### PR TITLE
Returned support for JWT_AUTH_ENDPOINT

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -221,8 +221,9 @@ class JWT(object):
         app.config.setdefault('JWT_SECRET_KEY', app.config['SECRET_KEY'])
 
         auth_url_rule = app.config.get('JWT_AUTH_URL_RULE', None)
+        endpoint = app.config.get('JWT_AUTH_ENDPOINT', None)
 
-        if auth_url_rule:
+        if auth_url_rule and endpoint:
             if self.auth_request_callback == _default_auth_request_handler:
                 assert self.authentication_callback is not None, (
                     'an authentication_handler function must be defined when using the built in '
@@ -230,6 +231,7 @@ class JWT(object):
 
             auth_url_options = app.config.get('JWT_AUTH_URL_OPTIONS', {'methods': ['POST']})
             auth_url_options.setdefault('view_func', self.auth_request_callback)
+            auth_url_options.setdefault('endpoint', endpoint)
             app.add_url_rule(auth_url_rule, **auth_url_options)
 
         app.errorhandler(JWTError)(self._jwt_error_callback)

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -46,7 +46,9 @@ def test_adds_auth_endpoint():
     app.config['JWT_AUTH_ENDPOINT'] = 'jwt_auth'
     flask_jwt.JWT(app, lambda: None, lambda: None)
     rules = [str(r) for r in app.url_map._rules]
+    endpoints = [r.endpoint for r in app.url_map.iter_rules()]
     assert '/auth' in rules
+    assert 'jwt_auth' in endpoints
 
 
 def test_auth_endpoint_with_valid_request(client, user):


### PR DESCRIPTION
As of 0.3.2, flask-jwt doesn't create a named auth endpoint (it is named `_default_auth_request_handler`).

Given that JWT_AUTH_ENDPOINT option is in the docs, I created this PR to restore endpoint naming functionality.
