### PR TITLE
Fix AttributeError on identity

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -50,7 +50,7 @@ def _default_jwt_payload_handler(identity):
     iat = datetime.utcnow()
     exp = iat + current_app.config.get('JWT_EXPIRATION_DELTA')
     nbf = iat + current_app.config.get('JWT_NOT_BEFORE_DELTA')
-    identity = getattr(identity, 'id') or identity['id']
+    identity = getattr(identity, 'id', None) or identity['id']
     return {'exp': exp, 'iat': iat, 'nbf': nbf, 'identity': identity}
 
 


### PR DESCRIPTION
When the user object returned by the authentication_handler is a dict, this exception is raised:
  File "/usr/local/lib/python2.7/dist-packages/flask_jwt/**init**.py", line 53, in _default_jwt_payload_handler
    identity = getattr(identity, 'id') or identity['id']
AttributeError: 'dict' object has no attribute 'id'
So getattr must not raise an exception but return None in order to evaluate the second par of the if: identity['id']
