### PR TITLE
Fix attribute error in default payload handler.

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -50,7 +50,7 @@ def _default_jwt_payload_handler(identity):
     iat = datetime.utcnow()
     exp = iat + current_app.config.get('JWT_EXPIRATION_DELTA')
     nbf = iat + current_app.config.get('JWT_NOT_BEFORE_DELTA')
-    identity = getattr(identity, 'id') or identity['id']
+    identity = getattr(identity, 'id', None) or identity['id']
     return {'exp': exp, 'iat': iat, 'nbf': nbf, 'identity': identity}
 
 

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -292,7 +292,7 @@ def test_custom_auth_handler():
         resp, jdata = post_json(c, '/auth', {})
         assert jdata == {'hello': 'world'}
 
-		
+
 def test_authentication_handler_with_dictionary_result(client, jwt, user):
     @jwt.authentication_handler
     def authenticate(username, password):
@@ -304,3 +304,4 @@ def test_authentication_handler_with_dictionary_result(client, jwt, user):
         client, '/auth', {'username': user.username, 'password': user.password})
     assert resp.status_code == 200
     assert 'access_token' in jdata
+

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -304,4 +304,3 @@ def test_authentication_handler_with_dictionary_result(client, jwt, user):
         client, '/auth', {'username': user.username, 'password': user.password})
     assert resp.status_code == 200
     assert 'access_token' in jdata
-

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -291,3 +291,16 @@ def test_custom_auth_handler():
     with app.test_client() as c:
         resp, jdata = post_json(c, '/auth', {})
         assert jdata == {'hello': 'world'}
+
+		
+def test_authentication_handler_with_dictionary_result(client, jwt, user):
+    @jwt.authentication_handler
+    def authenticate(username, password):
+        if username == user.username and password == user.password:
+            return dict(id=user.id, username=user.username, password=user.password)
+        return None
+
+    resp, jdata = post_json(
+        client, '/auth', {'username': user.username, 'password': user.password})
+    assert resp.status_code == 200
+    assert 'access_token' in jdata

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ deps =
     -r{toxinidir}/requirements-dev.txt
 
 commands =
-    py.test --clearcache {posargs} ./tests
+    py.test --cache-clear {posargs} ./tests


### PR DESCRIPTION
If the authentication handler returned a dictionary rather than an
object then the default payload handler would throw an AttributeError
as no default value was supplied for getattr().
