### PR TITLE
Fix renamed handler method names

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -271,7 +271,7 @@ class JWT(object):
         self.identity_callback = callback
         return callback
 
-    def jwt_error_handler(self, callback):
+    def error_handler(self, callback):
         """Specifies the error handler function. Example::
 
             @jwt.error_handler
@@ -314,7 +314,7 @@ class JWT(object):
         self.request_callback = callback
         return callback
 
-    def jwt_encode_handler(self, callback):
+    def encode_handler(self, callback):
         """Specifies the encoding handler function. This function receives a payload and signs it.
 
         :param callable callback: the encoding handler function
@@ -322,7 +322,7 @@ class JWT(object):
         self.jwt_encode_callback = callback
         return callback
 
-    def jwt_decode_handler(self, callback):
+    def decode_handler(self, callback):
         """Specifies the decoding handler function. This function receives a
         signed payload and decodes it.
 
@@ -331,7 +331,7 @@ class JWT(object):
         self.jwt_decode_callback = callback
         return callback
 
-    def jwt_payload_handler(self, callback):
+    def payload_handler(self, callback):
         """Specifies the JWT payload handler function. This function receives the return value from
         the ``identity_handler`` function
 
@@ -346,17 +346,17 @@ class JWT(object):
         self.jwt_payload_callback = callback
         return callback
 
-    def jwt_headers_handler(self, callback):
+    def headers_handler(self, callback):
         """Specifies the JWT header handler function. This function receives the return value from
         the ``identity_handler`` function.
 
         Example::
 
-            @jwt.payload_handler
-            def make_payload(identity):
+            @jwt.headers_handler
+            def make_headers(identity):
                 return {'user_id': identity.id}
 
-        :param callable callback: the payload handler function
+        :param callable callback: the header handler function
         """
         self.jwt_headers_callback = callback
         return callback

--- a/tests/test_jwt.py
+++ b/tests/test_jwt.py
@@ -182,7 +182,7 @@ def test_jwt_required_decorator_with_missing_user(client, jwt, user):
 
 
 def test_custom_error_handler(client, jwt):
-    @jwt.jwt_error_handler
+    @jwt.error_handler
     def error_handler(e):
         return "custom"
 
@@ -205,7 +205,7 @@ def test_custom_encode_handler(client, jwt, user, app):
     secret = app.config['JWT_SECRET_KEY']
     alg = 'HS256'
 
-    @jwt.jwt_encode_handler
+    @jwt.encode_handler
     def encode_data(identity):
         return _jwt.encode({'hello': 'world'}, secret, algorithm=alg)
 
@@ -223,7 +223,7 @@ def test_custom_decode_handler(client, user, jwt):
     def load_user(payload):
         assert payload == {'user_id': user.id}
 
-    @jwt.jwt_decode_handler
+    @jwt.decode_handler
     def decode_data(token):
         return {'user_id': user.id}
 
@@ -242,7 +242,7 @@ def test_custom_payload_handler(client, jwt, user):
         if payload['id'] == user.id:
             return user
 
-    @jwt.jwt_payload_handler
+    @jwt.payload_handler
     def make_payload(u):
         iat = datetime.utcnow()
         exp = iat + timedelta(seconds=60)


### PR DESCRIPTION
0.3 changed the names of some of the handler methods without warning.

Looks like most of the renaming happened in 2749d53, where it looks like a lot of other stuff went on as well.

The `jwt_` prefix added to these methods seems unnecessary. This opinion seems to be shared by others as well (see #65).
