### PR TITLE
Fix jwt_decode ignoring options

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -79,13 +79,13 @@ def _default_jwt_decode_handler(token):
     required_claims = current_app.config['JWT_REQUIRED_CLAIMS']
 
     options = {
-        'verify_' + claim: True
-        for claim in verify_claims
+        'verify_' + claim: claim in verify_claims
+        for claim in ['signature', 'exp', 'nbf', 'iat']
     }
 
     options.update({
-        'require_' + claim: True
-        for claim in required_claims
+        'require_' + claim: claim in required_claims
+        for claim in ['exp', 'nbf', 'iat']
     })
 
     return jwt.decode(token, secret, options=options, algorithms=[algorithm], leeway=leeway)


### PR DESCRIPTION
The JWT_VERIFY_CLAIMS and JWT_REQUIRED_CLAIMS assume that item precense
implies each item should be verified/required, and items that are excluded,
should NOT be verified or required.

Unfortunately, the PyJWT library will merge the supplied list of options
against a list of defaults:
https://github.com/jpadilla/pyjwt/blob/1.4.0/jwt/api_jwt.py#L74-L75

This means that if a user wanted to disable verification on expiration,
a user can NOT change
JWT_VERIFY_CLAIMS = ['signature', 'ext', 'nbf', 'iat']
to
JWT_VERIFY_CLAIMS = ['signature', 'nbf', 'iat']

If a user DOESN'T want it to verify the expiration, then they need to
explicitly set `verify_exp` to `False`.  The current algorithm will
look at the list, see that `verify_exp` was omitted, and pass in nothing
for `verify_exp` , which then makes the PyJWT assume a default (which is
`verify_exp=True`)

To fix, the _default_jwt_decode_handler was updated to generate an
options dictionary that sets each option to `True` or `False` so
JWT_VERIFY_CLAIMS = ['signature', 'nbf', 'iat']
Now will properly set `verify_ext=False`.
