### PR TITLE
correct duplicate docstring on different functions

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -292,7 +292,7 @@ class JWT(object):
         return callback
 
     def auth_request_handler(self, callback):
-        """Specifies the authentication response handler function.
+        """Specifies the authentication request handler function.
 
         :param callable callback: the auth request handler function
 


### PR DESCRIPTION
[These functions](https://github.com/mattupstate/flask-jwt/blob/master/flask_jwt/__init__.py#L286-L306) should have different descriptions in their docstrings.
