### PR TITLE
update _default_jwt_payload_handler

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -50,7 +50,7 @@ def _default_jwt_payload_handler(identity):
     iat = datetime.utcnow()
     exp = iat + current_app.config.get('JWT_EXPIRATION_DELTA')
     nbf = iat + current_app.config.get('JWT_NOT_BEFORE_DELTA')
-    identity = getattr(identity, 'id') or identity['id']
+    identity = identity['id'] if isinstance(identity, dict) else getattr(identity, 'id')  
     return {'exp': exp, 'iat': iat, 'nbf': nbf, 'identity': identity}
 
 


### PR DESCRIPTION
made changes to cater for when the instance of the return identity is a dictionary. 
the current code returns the following error

```
  identity = getattr(identity, 'id') or identity['id']
AttributeError: 'dict' object has no attribute 'id'

```
