### PR TITLE
AttributeError when identity is a dict

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -50,7 +50,7 @@ def _default_jwt_payload_handler(identity):
     iat = datetime.utcnow()
     exp = iat + current_app.config.get('JWT_EXPIRATION_DELTA')
     nbf = iat + current_app.config.get('JWT_NOT_BEFORE_DELTA')
-    identity = getattr(identity, 'id') or identity['id']
+    identity = getattr(identity, 'id', None) or identity['id']
     return {'exp': exp, 'iat': iat, 'nbf': nbf, 'identity': identity}
 
 


### PR DESCRIPTION
looking at the code, it seems like a dict `identity` should work, but it requires a small fix:

```python
  File "/home/anka/envs/modelrepository/lib/python3.6/site-packages/flask_restful/__init__.py", line 273, in error_router
    return original_handler(e)
  File "/home/anka/envs/modelrepository/lib/python3.6/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/home/anka/envs/modelrepository/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/home/anka/envs/modelrepository/lib/python3.6/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/anka/envs/modelrepository/lib/python3.6/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/anka/envs/modelrepository/lib/python3.6/site-packages/flask_jwt/__init__.py", line 127, in _default_auth_request_handler
    access_token = _jwt.jwt_encode_callback(identity)
  File "/home/anka/envs/modelrepository/lib/python3.6/site-packages/flask_jwt/__init__.py", line 62, in _default_jwt_encode_handler
    payload = _jwt.jwt_payload_callback(identity)
  File "/home/anka/envs/modelrepository/lib/python3.6/site-packages/flask_jwt/__init__.py", line 53, in _default_jwt_payload_handler
    identity = getattr(identity, 'id') or identity['id']
AttributeError: 'dict' object has no attribute 'id'
```