### PR TITLE
Fix some mistakes in doc strings (decorator names).

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -274,7 +274,7 @@ class JWT(object):
     def jwt_error_handler(self, callback):
         """Specifies the error handler function. Example::
 
-            @jwt.error_handler
+            @jwt.jwt_error_handler
             def error_handler(e):
                 return "Something bad happened", 400
 
@@ -337,7 +337,7 @@ class JWT(object):
 
         Example::
 
-            @jwt.payload_handler
+            @jwt.jwt_payload_handler
             def make_payload(identity):
                 return {'user_id': identity.id}
 
@@ -352,7 +352,7 @@ class JWT(object):
 
         Example::
 
-            @jwt.payload_handler
+            @jwt.jwt_headers_handler
             def make_payload(identity):
                 return {'user_id': identity.id}
 


### PR DESCRIPTION
There were some mistakes in the doc strings. I fixed them, please fix it on your documentation website.