### PR TITLE
_default_jwt_payload_handler: Check for attribute 'id'

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,13 @@ Flask-JWT Changelog
 
 Here you can see the full list of changes between each Flask-JWT release.
 
+Version 0.3.3
+-------------
+
+Released March 7th 2018 (by AbdealiJK)
+
+- Fixed an error when finding attribute 'id'
+
 Version 0.3.2
 -------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ copyright = u'2014, Matt Wright'
 # built documents.
 #
 # The short X.Y version.
-version = '0.3.2'
+version = '0.3.3'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -18,7 +18,7 @@ import jwt
 from flask import current_app, request, jsonify, _request_ctx_stack
 from werkzeug.local import LocalProxy
 
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,10 @@ def _default_jwt_payload_handler(identity):
     iat = datetime.utcnow()
     exp = iat + current_app.config.get('JWT_EXPIRATION_DELTA')
     nbf = iat + current_app.config.get('JWT_NOT_BEFORE_DELTA')
-    identity = getattr(identity, 'id') or identity['id']
+    if hasattr(identity, 'id'):
+        identity = getattr(identity, 'id')
+    else:
+        identity = identity['id']
     return {'exp': exp, 'iat': iat, 'nbf': nbf, 'identity': identity}
 
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ class PyTest(TestCommand):
 
 setup(
     name='Flask-JWT',
-    version='0.3.2',
+    version='0.3.3',
     url='https://github.com/mattupstate/flask-jwt',
     license='MIT',
     author='Matt Wright',


### PR DESCRIPTION
If the attribute 'id' does not exist, do not use it.
Use the item 'id' instead.

Fixes https://github.com/mattupstate/flask-jwt/issues/115