### PR TITLE
@jwt_required now returns correct error code with error message on JW…

### DIFF
--- a/flask_jwt/__init__.py
+++ b/flask_jwt/__init__.py
@@ -173,7 +173,10 @@ def jwt_required(realm=None):
     def wrapper(fn):
         @wraps(fn)
         def decorator(*args, **kwargs):
-            _jwt_required(realm or current_app.config['JWT_DEFAULT_REALM'])
+            try:
+                _jwt_required(realm or current_app.config['JWT_DEFAULT_REALM'])
+            except JWTError as e:
+                return {"message": e.description}, e.status_code
             return fn(*args, **kwargs)
         return decorator
     return wrapper


### PR DESCRIPTION
Old implementation always returns 500 error. Now, view that is wrapped with 'jwt_required' decorator returns an error with correct description and error code.